### PR TITLE
fix(glog): Fix glog android build error when the ndk api < 21.

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -24,7 +24,6 @@ config("glog_build") {
   include_dirs = [
     "third_party/include",
     "third_party/include/glog",
-    "third_party/glog/src",
   ]
   defines = [
     "DISABLE_RTTI",

--- a/third_party/glog_patch.diff
+++ b/third_party/glog_patch.diff
@@ -1,0 +1,14 @@
+diff --git a/src/logging.cc b/src/logging.cc
+index 0b5e6ee..8b1710e 100644
+--- a/src/logging.cc
++++ b/src/logging.cc
+@@ -1120,7 +1120,9 @@ void LogFileObject::Write(bool force_flush,
+       if (file_length_ >= logging::kPageSize) {
+         // don't evict the most recent page
+         uint32 len = file_length_ & ~(logging::kPageSize - 1);
++#if !defined(__ANDROID__) || !defined(__ANDROID_API__) || __ANDROID_API__ >= 21
+         posix_fadvise(fileno(file_), 0, len, POSIX_FADV_DONTNEED);
++#endif
+       }
+     }
+ #endif

--- a/third_party/include/glog/log_severity.h
+++ b/third_party/include/glog/log_severity.h
@@ -1,0 +1,1 @@
+../../glog/src/glog/log_severity.h


### PR DESCRIPTION
1. Remove third_party/glog/src from include_dirs.